### PR TITLE
[Wisp] Separate IO poller

### DIFF
--- a/jdk/src/linux/classes/com/alibaba/wisp/engine/WispConfiguration.java
+++ b/jdk/src/linux/classes/com/alibaba/wisp/engine/WispConfiguration.java
@@ -60,6 +60,7 @@ class WispConfiguration {
     static final int WISP_SCHEDULE_HELP_STEAL_RETRY;
     static final WispScheduler.SchedulingPolicy SCHEDULING_POLICY;
     static final boolean USE_DIRECT_SELECTOR_WAKEUP;
+    static final boolean SEPARATE_IO_POLLER;
     static final boolean CARRIER_AS_POLLER;
     static final boolean MONOLITHIC_POLL;
     static final boolean CARRIER_GROW;
@@ -113,7 +114,9 @@ class WispConfiguration {
             WISP_PROFILE_LOG_PATH = "";
         }
 
-        CARRIER_AS_POLLER = parseBooleanParameter(p, "com.alibaba.wisp.useCarrierAsPoller", ALL_THREAD_AS_WISP);
+        SEPARATE_IO_POLLER = parseBooleanParameter(p, "com.alibaba.wisp.separateIOPoller", false);
+        CARRIER_AS_POLLER = parseBooleanParameter(p, "com.alibaba.wisp.useCarrierAsPoller",
+                ALL_THREAD_AS_WISP && (!SEPARATE_IO_POLLER || WORKER_COUNT / POLLER_SHARDING_SIZE > 1));
         MONOLITHIC_POLL = parseBooleanParameter(p, "com.alibaba.wisp.monolithicPoll", true);
         WISP_HIGH_PRECISION_TIMER = parseBooleanParameter(p, "com.alibaba.wisp.highPrecisionTimer", false);
         WISP_ENGINE_TASK_CACHE_SIZE = parsePositiveIntegerParameter(p, "com.alibaba.wisp.engineTaskCache", 20);

--- a/jdk/test/com/alibaba/wisp2/bug/TestIssue311.java
+++ b/jdk/test/com/alibaba/wisp2/bug/TestIssue311.java
@@ -1,0 +1,52 @@
+/*
+ * @test
+ * @library /lib/testlibrary
+ * @summary Test different coroutines waiting on the same socket's read and write events.
+ * @requires os.family == "linux"
+ * @run main/timeout=10/othervm -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 -Dcom.alibaba.wisp.separateIOPoller=true TestIssue311
+ */
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.Socket;
+
+public class TestIssue311 {
+    public static void main(String[] args) throws Exception {
+        Socket client = startEchoServer();
+        new Thread(() -> {
+            try {
+                byte[] buf = new byte[1024];
+                while (true) { // discard all data
+                    client.getInputStream().read(buf, 0, buf.length);
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }).start();
+
+        byte[] buf = new byte[1024 * 1024];
+        for (int i = 0; i < 100; i++) {
+            client.getOutputStream().write(buf, 0, buf.length);
+        }
+    }
+
+
+    private static Socket startEchoServer() throws Exception {
+        ServerSocket serverSocket = new ServerSocket(0);
+        Socket socket = new Socket("localhost", serverSocket.getLocalPort());
+        new Thread(() -> {
+            try {
+                Socket clientSocket = serverSocket.accept();
+                byte[] buf = new byte[1024];
+                int len;
+                while ((len = clientSocket.getInputStream().read(buf)) > 0) {
+                    clientSocket.getOutputStream().write(buf, 0, len);
+                }
+                clientSocket.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }).start();
+        return socket;
+    }
+}


### PR DESCRIPTION
Summary: Supports different coroutines waiting on the same socket's read and write events. Solve a wisp bug triggered by okhttp.

Test Plan: TestIssue311

Reviewed-by: zhengxiaolinX, D-D-H

Issue: dragonwell-project/dragonwell8/issues/311