### PR TITLE
[EagerAppCDS] add `IgnoreAppCDSPathCheck` flag

### DIFF
--- a/hotspot/src/share/vm/classfile/sharedClassUtil.cpp
+++ b/hotspot/src/share/vm/classfile/sharedClassUtil.cpp
@@ -161,7 +161,7 @@ bool SharedPathsMiscInfoExt::check(jint type, const char* path) {
 
   switch (type) {
   case APP:
-    {
+    if (!IgnoreAppCDSPathCheck) {
       size_t len = strlen(path);
       const char *appcp = Arguments::get_appclasspath();
       assert(appcp != NULL, "NULL app classpath");

--- a/hotspot/src/share/vm/runtime/globals_ext.hpp
+++ b/hotspot/src/share/vm/runtime/globals_ext.hpp
@@ -174,6 +174,8 @@
           "Ignore non-empty dir check in AppCDS")                           \
   product(bool, CDSIgnoreBootClasspathDiff, false,                        \
           "keep AppCDS on after appending boot classpath")                  \
+  product(bool, IgnoreAppCDSPathCheck, false,                               \
+          "Ignore path check in AppCDS")                                    \
                                                                             \
   product(bool, SuppressAppCDSErrors, false,                                \
           "Suppress AppCDS errors during initialization; use warnings instead") \


### PR DESCRIPTION
Summary: Users can turn off the checking in a controlled environment if the classpath changed but they still wants to use cds.

Test Plan: ci jtreg cds

Reviewed-by: lingjun-cg, yuleil

Issue: https://github.com/dragonwell-project/dragonwell8/issues/565 CR: