### PR TITLE
[Misc] Enlarge default ReservedCodeCacheSize in aarch64 from 128m to …

### DIFF
--- a/hotspot/src/share/vm/runtime/arguments.cpp
+++ b/hotspot/src/share/vm/runtime/arguments.cpp
@@ -1165,12 +1165,7 @@ void Arguments::set_tiered_flags() {
   }
   // Increase the code cache size - tiered compiles a lot more.
   if (FLAG_IS_DEFAULT(ReservedCodeCacheSize)) {
-#ifndef AARCH64
     FLAG_SET_DEFAULT(ReservedCodeCacheSize, ReservedCodeCacheSize * 5);
-#else
-    FLAG_SET_DEFAULT(ReservedCodeCacheSize,
-                     MIN2(CODE_CACHE_DEFAULT_LIMIT, ReservedCodeCacheSize * 5));
-#endif
   }
   if (!UseInterpreter) { // -Xcomp
     Tier3InvokeNotifyFreqLog = 0;

--- a/hotspot/test/compiler/codecache/TestDefaultCodeCacheSize.sh
+++ b/hotspot/test/compiler/codecache/TestDefaultCodeCacheSize.sh
@@ -22,7 +22,7 @@
 #
 # @test
 # @summary test the default value of ReservedCodeCacheSize. It should be 240m
-# @run shell TestDefaultCodeCacheSize.sh 
+# @run shell TestDefaultCodeCacheSize.sh
 #
 
 ${TESTJAVA}/bin/java -XX:+PrintFlagsFinal -version | grep ReservedCodeCacheSize |grep 251658240

--- a/hotspot/test/compiler/codecache/TestDefaultCodeCacheSize.sh
+++ b/hotspot/test/compiler/codecache/TestDefaultCodeCacheSize.sh
@@ -1,0 +1,38 @@
+#
+# Copyright (c) 2023 Alibaba Group Holding Limited. All Rights Reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation. Alibaba designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+#
+# @test
+# @summary test the default value of ReservedCodeCacheSize. It should be 240m
+# @run shell TestDefaultCodeCacheSize.sh 
+#
+
+${TESTJAVA}/bin/java -XX:+PrintFlagsFinal -version | grep ReservedCodeCacheSize |grep 251658240
+
+if [ "0" == $? ];
+then
+    echo "ReservedCodeCacheSize is 240m"
+    echo "--- Test passed"
+else
+    echo "ReservedCodeCacheSize is not 240m"
+    echo "--- Test failed"
+    exit 1
+fi


### PR DESCRIPTION
…240m

Summary: In current jdk8 community master branch. Default value of ReservedCodeCacheSize on aarch64 systems is 128m while on all other architectures, the value is 240m. This difference may cause performance issues due to code cache full. This patch set ReservedCodeCacheSize on aarch64 to 240m, the same as other architectures.

Test Plan: hotspot/test/codecache/TestDefaultCodeCacheSize.sh

Reviewed-by: kuaiwei, JoshuaZhuwj

Issue: https://github.com/dragonwell-project/dragonwell8/issues/567