### PR TITLE
[EagerAppCDS] enable classpath change by replacing given env var

### DIFF
--- a/hotspot/src/share/vm/classfile/sharedClassUtil.hpp
+++ b/hotspot/src/share/vm/classfile/sharedClassUtil.hpp
@@ -82,6 +82,8 @@ class SharedPathsMiscInfoExt : public SharedPathsMiscInfo {
 
   virtual bool check(jint type, const char* path);
 
+  virtual bool checkAPP(const char* path);
+
   void add_app_classpath(const char* path) {
     add_path(path, APP);
   }

--- a/hotspot/src/share/vm/runtime/globals_ext.hpp
+++ b/hotspot/src/share/vm/runtime/globals_ext.hpp
@@ -174,6 +174,8 @@
           "Ignore non-empty dir check in AppCDS")                           \
   product(bool, CDSIgnoreBootClasspathDiff, false,                        \
           "keep AppCDS on after appending boot classpath")                  \
+  product(bool, CDSIgnoreFileTimeCheck, false,                           \
+          "do not check timestamp of jar file when using CDS")              \
                                                                             \
   product(bool, SuppressAppCDSErrors, false,                                \
           "Suppress AppCDS errors during initialization; use warnings instead") \

--- a/hotspot/src/share/vm/runtime/quickStart.hpp
+++ b/hotspot/src/share/vm/runtime/quickStart.hpp
@@ -87,6 +87,11 @@ private:
   static const char** _jvm_options;
   static const char* _cp_in_metadata_file;
 
+  // old env, new env
+  static GrowableArray<const char *>* old_envs;
+  static GrowableArray<const char *>* new_envs;
+  static int _max_env_diff_len; // len(new_env) - len(old_env)
+
   static bool set_optimization(const char* option, bool enabled);
   static bool determine_role(const JavaVMInitArgs* options_args);
   static bool prepare_dump(const JavaVMInitArgs* options_args);
@@ -110,6 +115,13 @@ private:
 public:
   static void set_opt_passed(opt feature);
   static void notify_dump();
+
+  static bool need_convert_path_by_env();
+  static void convert_path_by_env(const char* origin_path, char* new_path);
+  static char* replace_if_contains(const char* path);
+  static int get_max_replaced_path_len(const char* origin_path);
+private:
+  static void read_env_from_file_and_environment(char* line);
 
   // cds stuff
 private:

--- a/jdk/test/com/alibaba/quickstart/TestEnvClass.java
+++ b/jdk/test/com/alibaba/quickstart/TestEnvClass.java
@@ -1,0 +1,10 @@
+public class TestEnvClass {
+    public static void main(String[] args) {
+        System.out.println("==TestEnvClass2==");
+        TestEnvClass testEnvClass = new TestEnvClass();
+        testEnvClass.printClassName2();
+    }
+    public void printClassName2() {
+        System.out.println("==TestEnvClass2==");
+    }
+}

--- a/jdk/test/com/alibaba/quickstart/TestEnvVariableDump.java
+++ b/jdk/test/com/alibaba/quickstart/TestEnvVariableDump.java
@@ -1,0 +1,61 @@
+/*
+ * @test
+ * @summary Test Environment Variable Dump
+ * @library /lib /lib/testlibrary
+ * @requires os.arch=="amd64" | os.arch=="aarch64"
+ * @run main/othervm/timeout=600 TestEnvVariableDump
+ */
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+import java.io.*;
+import java.util.Map;
+import static jdk.testlibrary.Asserts.*;
+
+public class TestEnvVariableDump {
+    private static String cachepath = System.getProperty("user.dir");
+    private static final String metadata_file = "metadata";
+    private static final String hadoop_home = "/hadoop_home";
+    private static final String hadoop_common_home = "/hadoop_common_home";
+
+    public static void main(String[] args) throws Exception {
+        TestEnvVariableDump test = new TestEnvVariableDump();
+        cachepath = cachepath + "/testEnvVariableDump";
+        test.runAsTracer();
+        test.checkMetadataFile(cachepath + "/" + metadata_file);
+    }
+
+    private void runAsTracer() throws Exception {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-Xquickstart:path=" + cachepath, "-Xquickstart:verbose", "-Dcom.alibaba.cds.cp.reloc.envs=PWD,HADOOP_HOME,HADOOP_COMMON_HOME", "-XX:+IgnoreAppCDSDirCheck", "-version");
+        Map<String, String> env = pb.environment();
+        env.put("PWD", cachepath);
+        env.put("HADOOP_HOME", cachepath + hadoop_home);
+        env.put("HADOOP_COMMON_HOME", cachepath + hadoop_common_home);
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.shouldContain("Running as tracer");
+        output.shouldHaveExitValue(0);
+    }
+
+    private void checkMetadataFile(String filepath) {
+        boolean pwd_checked = false;
+        boolean hadoop_home_checked = false;
+        boolean hadoop_common_home_checked = false;
+        try {
+            BufferedReader in = new BufferedReader(new FileReader(filepath));
+            String str;
+            while ((str = in.readLine()) != null) {
+                if(str.contains("ENV.PWD")) {
+                    pwd_checked = str.contains(cachepath);
+                }
+                if(str.contains("ENV.HADOOP_HOME")) {
+                    hadoop_home_checked = str.contains(cachepath + hadoop_home);
+                }
+                if(str.contains("ENV.HADOOP_COMMON_HOME")) {
+                    hadoop_common_home_checked = str.contains(cachepath + hadoop_common_home);
+                }
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        assertTrue(pwd_checked && hadoop_home_checked && hadoop_common_home_checked);
+    }
+}

--- a/jdk/test/com/alibaba/quickstart/TestEnvVariableReplay.java
+++ b/jdk/test/com/alibaba/quickstart/TestEnvVariableReplay.java
@@ -1,0 +1,97 @@
+/*
+ * @test
+ * @summary Test Environment Variable Dump
+ * @library /lib /lib/testlibrary
+ * @requires os.arch=="amd64" | os.arch=="aarch64"
+ * @build TestEnvClass
+ * @run driver ClassFileInstaller -jar test.jar TestEnvClass
+ * @run main/othervm/timeout=600 TestEnvVariableReplay
+ */
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+import java.io.*;
+import java.util.Map;
+import static jdk.testlibrary.Asserts.*;
+
+public class TestEnvVariableReplay {
+
+    private static String TESTJAR = "/test.jar";
+    private static final String TESTNAME = "TestEnvClass";
+    private static final String TESTCLASS = TESTNAME + ".class";
+
+    private static String cachepath = System.getProperty("user.dir");
+    private static String newDir = System.getProperty("user.dir");
+    private static final String metadata_file = "metadata";
+    private static final String origin_home1 = "/origin_home1";
+    private static final String origin_home2 = "/origin_home2";
+    private static final String new_home1 = "/new_home1";
+    private static final String new_home2 = "/new_home2_long";
+    private static String classpath = "";
+
+    public static void main(String[] args) throws Exception {
+        TestEnvVariableReplay test = new TestEnvVariableReplay();
+        cachepath = cachepath + "/testEnvVariableDump";
+        newDir = newDir + "/newDir";
+        test.makeAllDir();
+        test.moveJar(System.getProperty("user.dir") + TESTJAR , newDir + origin_home1 + TESTJAR);
+        test.buildOriginClassPath();
+        test.runAsTracer();
+        test.moveJar(newDir + origin_home1 + TESTJAR, newDir + new_home1 + TESTJAR);
+        test.buildNewClassPath();
+        test.runAsReplayer();
+    }
+
+    private void makeAllDir() {
+        mkdir(newDir);
+        mkdir(newDir + origin_home1);
+        mkdir(newDir + origin_home2);
+        mkdir(newDir + new_home1);
+        mkdir(newDir + new_home2);
+    }
+
+    private void buildOriginClassPath() {
+        classpath = cachepath + ":" + newDir + origin_home1 + TESTJAR + ":" + newDir + origin_home2;
+    }
+
+    private void buildNewClassPath() {
+        classpath = cachepath + ":" + newDir + new_home1 + TESTJAR + ":" + newDir + new_home2;
+    }
+
+    private void moveJar(String from, String to) {
+        File file = new File(from);
+        assertTrue (file.renameTo(new File(to)));
+        file.delete();
+    }
+
+    private void mkdir(String dir_path){
+        try {
+            File dir = new File(dir_path);
+            dir.mkdir();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void runAsTracer() throws Exception {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-Xquickstart:path=" + cachepath, "-Xquickstart:verbose", "-Dcom.alibaba.cds.cp.reloc.envs=HOME1,HOME2", "-XX:+IgnoreAppCDSDirCheck", "-cp", classpath, TESTNAME);
+        Map<String, String> env = pb.environment();
+        env.put("HOME1", newDir + origin_home1);
+        env.put("HOME2", newDir + origin_home2);
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        System.out.println(output.getOutput());
+        output.shouldContain("Running as tracer");
+        output.shouldHaveExitValue(0);
+    }
+
+    private void runAsReplayer() throws Exception {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-Xquickstart:path=" + cachepath, "-Xquickstart:verbose", "-Dcom.alibaba.cds.cp.reloc.envs=HOME1,HOME2", "-XX:+IgnoreAppCDSDirCheck", "-XX:+TraceClassPaths", "-cp", classpath, TESTNAME);
+        Map<String, String> env = pb.environment();
+        env.put("HOME1", newDir + new_home1);
+        env.put("HOME2", newDir + new_home2);
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        System.out.println(output.getOutput());
+        output.shouldContain("Running as replayer");
+        output.shouldHaveExitValue(0);
+    }
+
+}


### PR DESCRIPTION
Summary: If user give environment vars and use
`-Dcom.alibaba.cds.cp.reloc.envs`, cds will change the classpath by using given environment vars to transform some paths in classpath.

Test Plan: ci jtreg
jdk/test/com/alibaba/quickstart/TestEnvVariableReplay.java jdk/test/com/alibaba/quickstart/TestEnvVariableDump.java

Reviewed-by: lingjun-cg, yuleil

Issue: https://github.com/dragonwell-project/dragonwell8/issues/595