### PR TITLE
[EagerAppCDS] fix bug: definePackage should check cld's parent

### DIFF
--- a/jdk/src/share/classes/java/lang/ClassLoader.java
+++ b/jdk/src/share/classes/java/lang/ClassLoader.java
@@ -1706,10 +1706,14 @@ public abstract class ClassLoader {
         throws IllegalArgumentException
     {
         Objects.requireNonNull(name);
-        Package pkg = new Package(name, specTitle, specVersion, specVendor,
-                implTitle, implVersion, implVendor,
-                sealBase, this);
-        if (packages.putIfAbsent(name, pkg) != null) {
+        Package pkg = getPackage(name);
+        if (pkg != null) {
+            throw new IllegalArgumentException(name);
+        }
+        final Package new_pkg = new Package(name, specTitle, specVersion, specVendor,
+                          implTitle, implVersion, implVendor,
+                          sealBase, this);
+        if (packages.computeIfAbsent(name, key -> new_pkg) != new_pkg) {
             throw new IllegalArgumentException(name);
         }
         return pkg;

--- a/jdk/test/java/lang/invoke/lambda/LogGeneratedClassesTest.java
+++ b/jdk/test/java/lang/invoke/lambda/LogGeneratedClassesTest.java
@@ -125,7 +125,8 @@ public class LogGeneratedClassesTest extends LUtils {
                                "-Djava.security.manager",
                                "com.example.TestLambda");
         // dump/com/example + 2 class files
-        assertEquals(Files.walk(Paths.get("dump")).count(), 5, "Two lambda captured");
+        // dump/java/lang + 1 class file
+        assertEquals(Files.walk(Paths.get("dump")).count(), 8, "Two lambda captured");
         tr.assertZero("Should still return 0");
     }
 
@@ -236,7 +237,8 @@ public class LogGeneratedClassesTest extends LUtils {
                                   .count(),
                      2, "show error each capture");
         // dumpLong/com/example/nosense/nosense
-        assertEquals(Files.walk(Paths.get("dumpLong")).count(), 5, "Two lambda captured failed to log");
+        // dumpLong/java/lang + 1 file
+        assertEquals(Files.walk(Paths.get("dumpLong")).count(), 8, "Two lambda captured failed to log");
         tr.assertZero("Should still return 0");
     }
 }


### PR DESCRIPTION
Summary: when call definePackage, it is necessary to check the existed key in its packages and its ancestors' packages

Test Plan: jck8d Package003 in JCK-runtime-8d/tests/api/java_lang/ClassLoader/PackageTests.java

Reviewed-by: lingjun-cg, yuleil

Issue: https://github.com/dragonwell-project/dragonwell8/issues/598