### PR TITLE
[EagerAppCDS] fix bug caused by using lambda in ClassLoader.java

### DIFF
--- a/jdk/src/share/classes/java/lang/ClassLoader.java
+++ b/jdk/src/share/classes/java/lang/ClassLoader.java
@@ -1710,10 +1710,10 @@ public abstract class ClassLoader {
         if (pkg != null) {
             throw new IllegalArgumentException(name);
         }
-        final Package new_pkg = new Package(name, specTitle, specVersion, specVendor,
+        pkg= new Package(name, specTitle, specVersion, specVendor,
                           implTitle, implVersion, implVendor,
                           sealBase, this);
-        if (packages.computeIfAbsent(name, key -> new_pkg) != new_pkg) {
+        if (packages.putIfAbsent(name, pkg) != null) {
             throw new IllegalArgumentException(name);
         }
         return pkg;

--- a/jdk/test/java/lang/invoke/lambda/LogGeneratedClassesTest.java
+++ b/jdk/test/java/lang/invoke/lambda/LogGeneratedClassesTest.java
@@ -125,8 +125,7 @@ public class LogGeneratedClassesTest extends LUtils {
                                "-Djava.security.manager",
                                "com.example.TestLambda");
         // dump/com/example + 2 class files
-        // dump/java/lang + 1 class file
-        assertEquals(Files.walk(Paths.get("dump")).count(), 8, "Two lambda captured");
+        assertEquals(Files.walk(Paths.get("dump")).count(), 5, "Two lambda captured");
         tr.assertZero("Should still return 0");
     }
 
@@ -237,8 +236,7 @@ public class LogGeneratedClassesTest extends LUtils {
                                   .count(),
                      2, "show error each capture");
         // dumpLong/com/example/nosense/nosense
-        // dumpLong/java/lang + 1 file
-        assertEquals(Files.walk(Paths.get("dumpLong")).count(), 8, "Two lambda captured failed to log");
+        assertEquals(Files.walk(Paths.get("dumpLong")).count(), 5, "Two lambda captured failed to log");
         tr.assertZero("Should still return 0");
     }
 }


### PR DESCRIPTION
Summary: Don't use lambda in ClassLoader.java since jvm may fail during initializing.

Testing: aqavit test

Reviewers: lingjun-cg, yuleil

Issue: https://github.com/dragonwell-project/dragonwell8/issues/603