### PR TITLE
[GC] fix complie errors for elastic-heap and jfr testcase

### DIFF
--- a/jdk/test/elastic-heap/TestElasticHeapErrorCode.java
+++ b/jdk/test/elastic-heap/TestElasticHeapErrorCode.java
@@ -32,7 +32,7 @@ import static jdk.test.lib.Asserts.*;
 
 /* @test
  * @summary test elastic-heap error code
- * @library /lib /
+ * @library /lib /test/lib
  * @compile TestElasticHeapErrorCode.java
  * @run main/othervm/timeout=100 TestElasticHeapErrorCode
  */

--- a/jdk/test/elastic-heap/TestElasticHeapMTSetError.java
+++ b/jdk/test/elastic-heap/TestElasticHeapMTSetError.java
@@ -32,7 +32,7 @@ import static jdk.test.lib.Asserts.*;
 
 /* @test
  * @summary test elastic-heap error with multiple threads setting
- * @library /lib /
+ * @library /lib /test/lib
  * @compile TestElasticHeapMTSetError.java
  * @run main/othervm/timeout=100 TestElasticHeapMTSetError
  */

--- a/jdk/test/elastic-heap/TestElasticHeapMXBean.java
+++ b/jdk/test/elastic-heap/TestElasticHeapMXBean.java
@@ -32,7 +32,7 @@ import static jdk.test.lib.Asserts.*;
 
 /* @test
  * @summary test elastic-heap MX bean
- * @library /lib /
+ * @library /lib /test/lib
  * @compile TestElasticHeapMXBean.java
  * @run main/othervm/timeout=100 TestElasticHeapMXBean
  */

--- a/jdk/test/elastic-heap/TestElasticHeapMXBeanException.java
+++ b/jdk/test/elastic-heap/TestElasticHeapMXBeanException.java
@@ -31,7 +31,7 @@ import static jdk.test.lib.Asserts.*;
 
 /* @test
  * @summary test elastic-heap MX bean exception
- * @library /lib /
+ * @library /lib /test/lib
  * @compile TestElasticHeapMXBeanException.java
  * @run main/othervm/timeout=100 TestElasticHeapMXBeanException
  */

--- a/jdk/test/jdk/jfr/jvm/TestClearStaleConstants.java
+++ b/jdk/test/jdk/jfr/jvm/TestClearStaleConstants.java
@@ -42,7 +42,7 @@ import jdk.test.lib.jfr.TestClassLoader;
  * @test
  * @bug 8231081
  * @key jfr
- * @library /lib /
+ * @library /lib /test/lib
  * @run main/othervm -Xmx16m jdk.jfr.jvm.TestClearStaleConstants
  */
 


### PR DESCRIPTION
Summary: As title.

Testing: ci jtreg
elastic-heap/TestElasticHeapErrorCode.java
elastic-heap/TestElasticHeapMTSetError.java
elastic-heap/TestElasticHeapMXBean.java
elastic-heap/TestElasticHeapMXBeanException.java
jdk/jfr/jvm/TestClearStaleConstants.java

Reviewers: lingjun-cg, yulei

Issue: https://github.com/dragonwell-project/dragonwell8/issues/620