### PR TITLE
[Backport] 8261354: SIGSEGV at MethodIteratorHost

### DIFF
--- a/hotspot/src/share/vm/jfr/recorder/checkpoint/types/jfrTypeSet.cpp
+++ b/hotspot/src/share/vm/jfr/recorder/checkpoint/types/jfrTypeSet.cpp
@@ -657,12 +657,11 @@ class MethodIteratorHost {
   bool operator()(KlassPtr klass) {
     if (_method_used_predicate(klass)) {
       const InstanceKlass* ik = InstanceKlass::cast((Klass*)klass);
-      const int len = ik->methods()->length();
-      Filter filter(ik->previous_versions() != NULL ? len : 0);
       while (ik != NULL) {
+        const int len = ik->methods()->length();
         for (int i = 0; i < len; ++i) {
           MethodPtr method = ik->methods()->at(i);
-          if (_method_flag_predicate(method) && filter(i)) {
+          if (_method_flag_predicate(method)) {
             _method_cb(method);
           }
         }


### PR DESCRIPTION
Summary: fix the bug imported by [Backport] 8230400: Missing constant pool entry for a method in stacktrace

Testing: ci jtreg, it's not easy to write a special testcase

Reviewers: zhuoang.ddh yibo

Issue: https://github.com/dragonwell-project/dragonwell8/issues/641

CR: https://github.com/dragonwell-project/dragonwell8/pull/642