### PR TITLE
[Backport] 6563994: assert(wf.check_method_context(ctxk, m), "proper …

### DIFF
--- a/hotspot/src/share/vm/code/dependencies.cpp
+++ b/hotspot/src/share/vm/code/dependencies.cpp
@@ -1578,6 +1578,10 @@ static bool overrides(Method* sub_m, Method* base_m) {
 // Include m itself in the set, unless it is abstract.
 // If this set has exactly one element, return that element.
 Method* Dependencies::find_unique_concrete_method(Klass* ctxk, Method* m) {
+  // Return NULL if m is marked old; must have been a redefined method.
+  if (m->is_old()) {
+    return NULL;
+  }
   ClassHierarchyWalker wf(m);
   assert(wf.check_method_context(ctxk, m), "proper context");
   wf.record_witnesses(1);


### PR DESCRIPTION
…context") failed

Summary: Check for redefined method before finding unique concrete method

Testing: jdk/jfr/event/os/TestCPUTimeStampCounter.java

Reviewers: sendaoYan, D-D-H

Issue: https://github.com/dragonwell-project/dragonwell8/issues/656