### PR TITLE
[GC] Fix option type in IOPrioritySizePolicy

### DIFF
--- a/hotspot/src/share/vm/runtime/globals_ext.hpp
+++ b/hotspot/src/share/vm/runtime/globals_ext.hpp
@@ -198,7 +198,7 @@
   product(bool, UseIOPrioritySizePolicy, false,                             \
           "eagerly decrease heap when io wait is high")                     \
                                                                             \
-  product(float, IOPrioritySizePolicyEdenScale, 8.0,                        \
+  product(uintx, IOPrioritySizePolicyEdenScale, 8,                           \
           "how much eden to decrease when io wait is high")                 \
 
   //add new AJVM specific flags here


### PR DESCRIPTION
Summary: change type from float to uint for IOPrioritySizePolicyEdenScale to avoid build failure on aarch64

Testing: maoliang.ml, yude.lyd

Reviewers: maoliang.ml, yude.lyd

Issue: https://github.com/dragonwell-project/dragonwell8/issues/664

CR: https://github.com/dragonwell-project/dragonwell8/pull/663