### PR TITLE
[GC] Fix activation mechanism for IOPrioritySizePolicy

### DIFF
--- a/hotspot/src/share/vm/runtime/arguments.cpp
+++ b/hotspot/src/share/vm/runtime/arguments.cpp
@@ -1664,9 +1664,12 @@ void Arguments::set_parallel_gc_flags() {
       FLAG_SET_DEFAULT(MaxHeapFreeRatio, 100);
       _max_heap_free_ratio = MaxHeapFreeRatio;
     }
+#if defined(LINUX) && (defined(AMD64) || (defined(AARCH64)))
+    // Auto-Enabled only on linux-x64 or arm64
     if (FLAG_IS_DEFAULT(UseIOPrioritySizePolicy)) {
       FLAG_SET_DEFAULT(UseIOPrioritySizePolicy, true);
     }
+#endif
   }
 
   if (UseIOPrioritySizePolicy && !UseAdaptiveSizePolicy) {


### PR DESCRIPTION
Summary: do not enable IOPrioritySizePolicy automatically on windows
Testing: jtreg
Reviewers: yyang, yude.lyd
Issue: https://github.com/dragonwell-project/dragonwell8/issues/685