### PR TITLE
[JFR] Test jfr/event/gc/detailed/TestPromotionFailedEventWithParallelScavenge.java crash

### DIFF
--- a/hotspot/src/share/vm/jfr/recorder/repository/jfrEmergencyDump.cpp
+++ b/hotspot/src/share/vm/jfr/recorder/repository/jfrEmergencyDump.cpp
@@ -306,7 +306,7 @@ static const char* create_emergency_chunk_path(const char* repository_path) {
     return NULL;
   }
   // append the individual substrings
-  jio_snprintf(chunk_path, chunkname_max_len, "%s%s%s%s", repository_path_len, os::file_separator(), date_time_buffer, chunk_file_jfr_ext);
+  jio_snprintf(chunk_path, chunkname_max_len, "%s%s%s%s", repository_path, os::file_separator(), date_time_buffer, chunk_file_jfr_ext);
   return chunk_path;
 }
 


### PR DESCRIPTION
Summary: The format of snprintf expect a string, but pass an integer value in function create_emergency_chunk_path which defined in file jfrEmergencyDump.cpp.

Testing: jfr/event/gc/detailed/TestPromotionFailedEventWithParallelScavenge.java

Reviewers: sendaoYan, D-D-H

Issue: https://github.com/dragonwell-project/dragonwell8/issues/690
